### PR TITLE
fix: reworked addMeal function to save the dummy client order

### DIFF
--- a/server/users/userController.js
+++ b/server/users/userController.js
@@ -102,19 +102,18 @@ module.exports = {
   },
 
   addMeal: function (req,res,next){
+    var update;
 
-    var username = req.body.username,
-    update;
-
-     
-     if (req.body.orders.length>0) { 
+    if (req.body.hasOwnProperty('orders')) { 
       //then we have an order (customer)
-      var title = req.body.orders[0].title,
+      var username = req.body.orders[0].username,
+      title = req.body.orders[0].title,
       price = req.body.orders[0].price,
       description = req.body.orders[0].description, 
       ingredients = req.body.orders[0].ingredients,
       field = "orders"
-    } else {
+      
+     } else {
       //then we have a meal (vendor)
       var title = req.body.meals[0].title,
       price = req.body.meals[0].price,
@@ -164,6 +163,8 @@ module.exports = {
       });
     
   }
+
+
 
  
 


### PR DESCRIPTION
reworked serverside addMeal function such that the order sent over from the client it saved to the database. 
the order currently being sent over is in the form:     

var mealToOrder = {orders: [{username: "sonny", title: "Taco", price: 7,description: "Try my taco tacos"}]};

this must be constructed client side and submitted in the above form :)
